### PR TITLE
[MOBILE-686] Fix ecash connection

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,7 @@ timber = "5.0.1"
 
 tonKotlin = "0.5.0" # updated for ktor 3.x compatibility
 piratecash-ton = "v1.0.0-pcash.1"
-piratecash-bitcoin = "v0.1.0-pcash.8"
+piratecash-bitcoin = "v0.1.0-pcash.9"
 stellar-kit = "c2b7994"
 piratecash-ethereum = "633b922"
 horizontalsystems-blockchain-fee = "393cc14"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,7 @@ timber = "5.0.1"
 
 tonKotlin = "0.5.0" # updated for ktor 3.x compatibility
 piratecash-ton = "v1.0.0-pcash.1"
-piratecash-bitcoin = "v0.1.0-pcash.9"
+piratecash-bitcoin = "v0.1.0-pcash.13"
 stellar-kit = "c2b7994"
 piratecash-ethereum = "633b922"
 horizontalsystems-blockchain-fee = "393cc14"


### PR DESCRIPTION
Updates Bitcoin Kit dependency to v0.1.0-pcash.9 after JitPack build succeeded.